### PR TITLE
Chore: Update README.md - Add link to actual blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Cloud Artisan Blog
+# [Cloud Artisan Blog](https://cloudartisan.com/)
 
 [![Deploy Hugo site](https://github.com/cloudartisan/cloudartisan.github.io/actions/workflows/hugo.yml/badge.svg)](https://github.com/cloudartisan/cloudartisan.github.io/actions/workflows/hugo.yml)
 
-Personal blog and project showcase for David Taylor (Cloud Artisan).
+Personal [blog](https://cloudartisan.com/) and project showcase for David Taylor (Cloud Artisan).
 
 ## Technology
 


### PR DESCRIPTION
I came across this repository, and I wanted to check out the cloudartisan.github.io / cloudartisan.com site, and I couldn't find a direct link on the page, so I just thought it might be nice to add one. Just a quick suggestion!