### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      timezone: "Australia/Sydney"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      timezone: "Australia/Sydney"
+  - package-ecosystem: "pip"
+    directory: "/scripts"
+    schedule:
+      interval: "weekly"
+      timezone: "Australia/Sydney"


### PR DESCRIPTION
## Summary
- monitor Go module, GitHub Action, and Python script dependencies with Dependabot

## Testing
- `go install -tags extended github.com/gohugoio/hugo@v0.145.0` *(fails: Forbidden)*
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d22f8a9c8322a7b97f4529c1aab8