### PR TITLE
chore: update workflow action versions

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,5 +1,5 @@
 # Version-locked deployment workflow for Hugo site with Congo theme
-# Hugo 0.148.1 + Congo v2.12.2 + Go 1.20.14 for reproducible builds
+# Hugo 0.149.0 + Congo v2.12.2 + Go 1.25.0 for reproducible builds
 name: Deploy Hugo site
 
 on:
@@ -20,12 +20,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.2.0
         with:
-          go-version: '1.20.14'  # Pin to specific Go version for reproducible builds
+          go-version: '1.25.0'  # Pin to specific Go version for reproducible builds
       
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2.6.0
         with:
-          hugo-version: '0.148.1'  # Pin to 0.148.1 for Congo v2.12.2 compatibility
+          hugo-version: '0.149.0'  # Pin to 0.149.0 for Congo v2.12.2 compatibility
           extended: true
 
       - name: Debug Environment

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -13,17 +13,17 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Go
-        uses: actions/setup-go@v5.2.0
+        uses: actions/setup-go@v5.5.0
         with:
           go-version: '1.25.0'  # Pin to specific Go version for reproducible builds
       
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2.6.0
+        uses: peaceiris/actions-hugo@v3.0.0
         with:
           hugo-version: '0.149.0'  # Pin to 0.149.0 for Congo v2.12.2 compatibility
           extended: true

--- a/AI.md
+++ b/AI.md
@@ -17,7 +17,7 @@
 - Repository is cloudartisan.github.io
 
 ## Build Commands
-- Install Hugo: `go install -tags extended github.com/gohugoio/hugo@v0.145.0`
+- Install Hugo: `go install -tags extended github.com/gohugoio/hugo@v0.149.0`
 - Update theme modules: `hugo mod get -u`
 - Local development: `hugo server -D` (includes draft content)
 - Production build: `hugo` (generates static site in /public)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This site is built with:
 
 2. Install Hugo (specific version to ensure compatibility):
    ```
-   go install -tags extended github.com/gohugoio/hugo@v0.145.0
+    go install -tags extended github.com/gohugoio/hugo@v0.149.0
    ```
    
    Ensure your Go bin directory (typically ~/go/bin) is in your PATH.

--- a/content/posts/2025-04-16-claude-code-tips-memory.md
+++ b/content/posts/2025-04-16-claude-code-tips-memory.md
@@ -87,7 +87,7 @@ For this Hugo website, I have a project-specific [`CLAUDE.md`](https://github.co
 - Follow Congo theme conventions
 
 ## Build Commands
-- Install Hugo: `go install -tags extended github.com/gohugoio/hugo@v0.145.0`
+ - Install Hugo: `go install -tags extended github.com/gohugoio/hugo@v0.149.0`
 - Local development: `hugo server -D` (includes draft content)
 - Production build: `hugo` (generates static site in /public)
 - Create new post: `hugo new content/posts/my-post-name.md`

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cloudartisan/cloudartisan.github.io
 
-go 1.20
+go 1.25
 
 require github.com/jpanther/congo/v2 v2.12.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,3 @@
-github.com/jpanther/congo/v2 v2.11.0 h1:whwuUIn20egAPfMR3HaFu7sW7/rz096bz26sgpsUAwk=
-github.com/jpanther/congo/v2 v2.11.0/go.mod h1:1S7DRoO1ZYS4YUdFd1LjTkdyjQwsjFWd8TqSfz3Jd+M=
-github.com/jpanther/congo/v2 v2.12.1 h1:HwMaU1k0ZhKa8DNYNKn+UKyK+8lf3TvVYZ/z3YknlC4=
-github.com/jpanther/congo/v2 v2.12.1/go.mod h1:1S7DRoO1ZYS4YUdFd1LjTkdyjQwsjFWd8TqSfz3Jd+M=
 github.com/jpanther/congo/v2 v2.12.2 h1:dr7oI/as+g+FJ6zVLZ3LSVOSRlsJjSsvTO6YP4zbOsQ=
 github.com/jpanther/congo/v2 v2.12.2/go.mod h1:1S7DRoO1ZYS4YUdFd1LjTkdyjQwsjFWd8TqSfz3Jd+M=
+


### PR DESCRIPTION
## Summary
- upgrade actions/checkout to 5.0.0
- upgrade actions/setup-go to 5.5.0
- upgrade peaceiris/actions-hugo to 3.0.0

## Testing
- `hugo version` *(fails: command not found)*
- `hugo server -D` *(fails: command not found)*
- `hugo server --navigateToChanged` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b67297f0fc8322b386f7937f420994