### PR TITLE
Add post PR helper note to AI.md

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -99,6 +99,7 @@
 
 ## Pull Request Workflow
 - For significant changes, create a feature branch and PR instead of pushing directly to main
+- For new blog posts, you can use `./scripts/create-post-pr.sh "Post Title Here"` to create the branch and starter post file
 - The PR validation workflow will automatically test:
   - Hugo build success (both development and production)
   - Content validation (front matter, required fields)


### PR DESCRIPTION
## Summary
- add one explicit note in `AI.md` that new blog posts can be started with `./scripts/create-post-pr.sh "Post Title Here"`

## Why
The current guide already documents the wrapper-based Hugo workflow correctly. The only useful addition from the earlier review was an explicit pointer in the PR workflow section to the helper script for creating a post branch and starter file.

## Validation
- confirmed `scripts/create-post-pr.sh` exists in the repo
- confirmed the rest of the current `AI.md` Hugo guidance already matches the repo's wrapper-based workflow
